### PR TITLE
Add developer tools for testing and rebasing.

### DIFF
--- a/bin/git
+++ b/bin/git
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# To rebase on main, run:
+# ./bin/git 'rebase main'
+
+branches=$(eval "git branch | grep 'lab' | xargs")
+
+git checkout main
+for branch in $branches
+do
+  eval "git $1 ${branch}"
+done
+git checkout main

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+branches=$(eval "git branch | grep 'lab' | xargs")
+
+git checkout main
+for branch in $branches
+do
+  echo "Testing branch ${branch}"
+  eval "git checkout ${branch}"
+  python manage.py test
+  python manage.py test --tag lab_test
+done
+git checkout main


### PR DESCRIPTION
bin/git can be used to run a git command on all the lab branches. This makes rebasing on main significantly easier in the future which will be helpful when upgrading versions. I didn't test the case of a conflict, so have fun with that Future Tim.

bin/test can be used to run all unit tests, including the lab tests for each branch. It's great for running the full test suite without relying on CI.