### PR TITLE
docs: fix virtual environment instruction typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ please scroll down to [Windows non-WSL Setup](#windows-non-wsl-setup).
    ```shell
    python -m venv venv
    ```
-2. Active the virtual environment.
+2. Activate the virtual environment.
    ```shell
    source venv/bin/activate
    ```


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary
- Correct `Active the virtual environment` to `Activate the virtual environment` in the setup steps.

Fixes #17

## Test plan
- static validation: `Active the virtual environment` appeared 1 time(s) before replacement.
- static validation: `Active the virtual environment` absent and `Activate the virtual environment` present after patch.
- Not run: runtime test suite, because this is a documentation-only fix.
